### PR TITLE
Update use of Packaging library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 import re
 import pathlib
 import setuptools
+
+setuptools.dist.Distribution().fetch_build_eggs(['packaging'])
 import packaging.version
 
 
@@ -17,7 +19,9 @@ match = re.search(pattern, init_text, re.M)
 if not match:
     raise RuntimeError(f'Unable to find __version__ in {init_file}.')
 version = match.group(1)
-if isinstance(packaging.version.parse(version), packaging.version.LegacyVersion):
+try:
+    packaging.version.parse(version)
+except packaging.version.InvalidVersion:
     raise RuntimeError(f'Invalid version string {version}.')
 
 # run setup


### PR DESCRIPTION
Adapt setup.py to be able to `pip install git+https://github.com/adalca/pystrum.git` without the below error.
```
Collecting git+https://github.com/adalca/pystrum.git@8552489
  Cloning https://github.com/adalca/pystrum.git (to revision 8552489) to ./pip-req-build-y7uxjtkg
  Running command git clone --filter=blob:none --quiet https://github.com/adalca/pystrum.git /tmp/pip-req-build-y7uxjtkg
  WARNING: Did not find branch or tag '8552489', assuming revision or ref.
  Running command git checkout -q 8552489
  Resolved https://github.com/adalca/pystrum.git to commit 8552489
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-req-build-y7uxjtkg/setup.py", line 6, in <module>
          import packaging.version
      ModuleNotFoundError: No module named 'packaging'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```